### PR TITLE
Refactor booster handling

### DIFF
--- a/assets/scripts/models/BoosterType.ts
+++ b/assets/scripts/models/BoosterType.ts
@@ -1,0 +1,4 @@
+export enum BoosterType {
+  Bomb = "bomb",
+  Teleport = "teleport",
+}

--- a/assets/scripts/models/BoosterType.ts.meta
+++ b/assets/scripts/models/BoosterType.ts.meta
@@ -1,0 +1,10 @@
+{
+  "ver": "1.1.0",
+  "uuid": "e6ad2fd8-0000-0000-0000-000000000000",
+  "importer": "typescript",
+  "isPlugin": false,
+  "loadPluginInWeb": true,
+  "loadPluginInNative": true,
+  "loadPluginInEditor": false,
+  "subMetas": {}
+}

--- a/assets/scripts/models/GameFactory.ts
+++ b/assets/scripts/models/GameFactory.ts
@@ -3,6 +3,8 @@ import { BoardModel } from "./BoardModel";
 import { BombBooster, TeleportBooster } from "./Boosters";
 import { SuperHandlerFactory } from "./SuperHandlers";
 import { ClickProcessor } from "./ClickProcessor";
+import { BoosterType } from "./BoosterType";
+import { IBooster } from "./IBooster";
 
 export class GameFactory {
   create(rows: number, cols: number, moves: number, target: number): GameModel {
@@ -10,7 +12,11 @@ export class GameFactory {
     const bomb = new BombBooster(1);
     const teleport = new TeleportBooster();
     const superFactory = new SuperHandlerFactory(bomb.blastRadius);
-    const processor = new ClickProcessor(board, bomb, teleport, superFactory);
-    return new GameModel(board, moves, target, processor, bomb, teleport);
+    const boosters: Map<BoosterType, IBooster> = new Map([
+      [BoosterType.Bomb, bomb],
+      [BoosterType.Teleport, teleport],
+    ]);
+    const processor = new ClickProcessor(board, boosters, superFactory);
+    return new GameModel(board, moves, target, processor, boosters);
   }
 }

--- a/assets/scripts/models/GameModel.ts
+++ b/assets/scripts/models/GameModel.ts
@@ -2,6 +2,7 @@ import { IBoardModel } from "./IBoardModel";
 import { IBooster } from "./IBooster";
 import { ClickResult } from "./ClickResult";
 import { IClickProcessor } from "./IClickProcessor";
+import { BoosterType } from "./BoosterType";
 
 export class GameModel {
   board: IBoardModel;
@@ -11,8 +12,7 @@ export class GameModel {
   shuffleCount = 0;
   maxShuffles = 3;
 
-  public readonly bomb: IBooster;
-  public readonly teleport: IBooster;
+  private boosters: Map<BoosterType, IBooster>;
   private clickProcessor: IClickProcessor;
 
   constructor(
@@ -20,29 +20,35 @@ export class GameModel {
     moves: number,
     target: number,
     clickProcessor: IClickProcessor,
-    bomb: IBooster,
-    teleport: IBooster
+    boosters: Map<BoosterType, IBooster>
   ) {
     this.board = board;
     this.movesLeft = moves;
     this.targetScore = target;
     this.clickProcessor = clickProcessor;
-    this.bomb = bomb;
-    this.teleport = teleport;
+    this.boosters = boosters;
+  }
+
+  public get bomb(): IBooster | undefined {
+    return this.boosters.get(BoosterType.Bomb);
+  }
+
+  public get teleport(): IBooster | undefined {
+    return this.boosters.get(BoosterType.Teleport);
   }
 
   public get bombCount(): number {
-    return this.bomb.count;
+    return this.bomb ? this.bomb.count : 0;
   }
 
   public get teleportCount(): number {
-    return this.teleport.count;
+    return this.teleport ? this.teleport.count : 0;
   }
 
   public click(
     row: number,
     col: number,
-    useBooster: string | null = null,
+    useBooster: BoosterType | null = null,
     r2?: number,
     c2?: number
   ): ClickResult {

--- a/assets/scripts/models/IClickProcessor.ts
+++ b/assets/scripts/models/IClickProcessor.ts
@@ -2,8 +2,8 @@ export interface IClickProcessor {
   process(
     row: number,
     col: number,
-    useBooster?: string | null,
+    useBooster?: import("./BoosterType").BoosterType | null,
     r2?: number,
     c2?: number
-  ): import('./ClickProcessor').ClickOutcome;
+  ): import("./ClickProcessor").ClickOutcome;
 }

--- a/assets/scripts/views/GameController.ts
+++ b/assets/scripts/views/GameController.ts
@@ -5,6 +5,7 @@ import { ClickResult } from "../models/ClickResult";
 import { GridView } from "./GridView";
 import { IGridView } from "./IGridView";
 import { GameFactory } from "../models/GameFactory";
+import { BoosterType } from "../models/BoosterType";
 const { ccclass, property } = cc._decorator;
 
 @ccclass
@@ -37,7 +38,7 @@ export default class GameController extends cc.Component {
   @property(cc.Label) countTeleportLabel!: cc.Label;
   private model!: GameModel;
   private gridView!: IGridView;
-  private useBooster: string | null = null;
+  private useBooster: BoosterType | null = null;
   private teleportFrom: [number, number] | null = null;
   private gameFactory: GameFactory = new GameFactory();
 
@@ -165,7 +166,7 @@ private onRestartCustom() {
   private async onTileClicked(row: number, col: number) {
     let res: ClickResult;
 
-    if (this.useBooster === "teleport") {
+    if (this.useBooster === BoosterType.Teleport) {
       if (!this.teleportFrom) {
         this.teleportFrom = [row, col];
         this.updateUI();
@@ -173,7 +174,7 @@ private onRestartCustom() {
       }
 
       const [r1, c1] = this.teleportFrom;
-      res = this.model.click(row, col, "teleport", r1, c1);
+      res = this.model.click(row, col, BoosterType.Teleport, r1, c1);
 
       if (res.moved.length === 0) {
         this.teleportFrom = null;
@@ -222,8 +223,8 @@ private onRestartCustom() {
     this.movesLabel.string = `${this.model.movesLeft}`;
 
     // новые строчки
-    this.countBombLabel.string = `${this.model.bomb.count}`;
-    this.countTeleportLabel.string = `${this.model.teleport.count}`;
+    this.countBombLabel.string = `${this.model.bomb ? this.model.bomb.count : 0}`;
+    this.countTeleportLabel.string = `${this.model.teleport ? this.model.teleport.count : 0}`;
     // this.boosterLabel.string = this.useBooster
     //   ? `Booster: ${this.useBooster}`
     //   : "Booster: none";
@@ -232,15 +233,15 @@ private onRestartCustom() {
 
   /** Бомба */
   public onBombButton() {
-    this.useBooster = "bomb";
+    this.useBooster = BoosterType.Bomb;
     this.updateUI();
   }
 
   /** Телепорт */
   public onTeleportButton() {
     // if (!this.teleportFrom) this.teleportFrom = [0, 0];
-    // this.useBooster = "teleport";
-    this.useBooster = "teleport";
+    // this.useBooster = BoosterType.Teleport;
+    this.useBooster = BoosterType.Teleport;
     this.teleportFrom = null;
     this.updateUI();
   }


### PR DESCRIPTION
## Summary
- add `BoosterType` enum
- store boosters in a map within `ClickProcessor`
- adjust `GameModel` to hold booster map
- adapt `GameFactory` and `GameController` to use the new booster system

## Testing
- `npx tsc --noEmit` *(fails: creator.d.ts error)*

------
https://chatgpt.com/codex/tasks/task_e_6857f98374908321bfa644fbc8ee40c3