### PR TITLE
Add manual shuffle button

### DIFF
--- a/assets/scripts/models/GameModel.ts
+++ b/assets/scripts/models/GameModel.ts
@@ -41,6 +41,21 @@ export class GameModel {
     return this.teleport.count;
   }
 
+  public get shuffleLeft(): number {
+    return Math.max(this.maxShuffles - this.shuffleCount, 0);
+  }
+
+  public canShuffle(): boolean {
+    return this.shuffleLeft > 0;
+  }
+
+  public manualShuffle(): boolean {
+    if (!this.canShuffle()) return false;
+    this.board.shuffle();
+    this.shuffleCount++;
+    return true;
+  }
+
   public click(
     row: number,
     col: number,

--- a/assets/scripts/views/ButtonActiveEffect.ts
+++ b/assets/scripts/views/ButtonActiveEffect.ts
@@ -1,0 +1,38 @@
+const { ccclass, property } = cc._decorator;
+
+@ccclass
+export default class ButtonActiveEffect extends cc.Component {
+  @property
+  scaleFactor: number = 1.1;
+
+  @property
+  duration: number = 0.4;
+
+  private tween?: cc.Tween;
+
+  onEnable() {
+    this.startTween();
+  }
+
+  onDisable() {
+    this.stopTween();
+  }
+
+  private startTween() {
+    this.tween = cc.tween(this.node)
+      .repeatForever(
+        cc.tween()
+          .to(this.duration, { scale: this.scaleFactor })
+          .to(this.duration, { scale: 1 })
+      )
+      .start();
+  }
+
+  private stopTween() {
+    if (this.tween) {
+      this.tween.stop();
+      this.node.scale = 1;
+      this.tween = undefined;
+    }
+  }
+}

--- a/assets/scripts/views/ButtonActiveEffect.ts.meta
+++ b/assets/scripts/views/ButtonActiveEffect.ts.meta
@@ -1,0 +1,10 @@
+{
+  "ver": "1.1.0",
+  "uuid": "f1e66b24-378e-4dbc-8a20-703f707a8e8b",
+  "importer": "typescript",
+  "isPlugin": false,
+  "loadPluginInWeb": true,
+  "loadPluginInNative": true,
+  "loadPluginInEditor": false,
+  "subMetas": {}
+}

--- a/assets/scripts/views/UIManager.ts
+++ b/assets/scripts/views/UIManager.ts
@@ -1,6 +1,7 @@
 import { BoosterType } from "../models/BoosterType";
 import { GameModel } from "../models/GameModel";
 import ButtonHoverEffect from "./ButtonHoverEffect";
+import ButtonActiveEffect from "./ButtonActiveEffect";
 
 export class UIManager {
   constructor(
@@ -13,17 +14,20 @@ export class UIManager {
     private startCustomBtn: cc.Button,
     private bombButton: cc.Button,
     private teleportButton: cc.Button,
+    private shuffleButton: cc.Button,
     private scoreLabel: cc.Label,
     private movesLabel: cc.Label,
     private countBombLabel: cc.Label,
     private countTeleportLabel: cc.Label,
+    private countShuffleLabel: cc.Label,
     private restartGame: (
       rows: number,
       cols: number,
       moves: number,
       target: number
     ) => void,
-    private onBoosterSelect: (booster: BoosterType) => void
+    private onBoosterSelect: (booster: BoosterType) => void,
+    private onShuffle: () => void
   ) {}
 
   public init() {
@@ -47,8 +51,12 @@ export class UIManager {
     this.startCustomBtn.node.on("click", this.onRestartCustom, this);
     this.bombButton.node.on("click", this.onBombButton, this);
     this.teleportButton.node.on("click", this.onTeleportButton, this);
-        this.bombButton.node.addComponent(ButtonHoverEffect);
+    this.shuffleButton.node.on("click", this.onShuffleButton, this);
+    this.bombButton.node.addComponent(ButtonHoverEffect);
     this.teleportButton.node.addComponent(ButtonHoverEffect);
+    this.shuffleButton.node.addComponent(ButtonHoverEffect);
+    this.bombButton.node.addComponent(ButtonActiveEffect).enabled = false;
+    this.teleportButton.node.addComponent(ButtonActiveEffect).enabled = false;
   }
 
   public hideAllPopups() {
@@ -71,10 +79,16 @@ export class UIManager {
     this.movesLabel.string = `${model.movesLeft}`;
     this.countBombLabel.string = `${model.bomb.count}`;
     this.countTeleportLabel.string = `${model.teleport.count}`;
-        this.bombButton.interactable = model.bomb.count > 0;
+    this.countShuffleLabel.string = `${model.shuffleLeft}`;
+    this.bombButton.interactable = model.bomb.count > 0;
     this.teleportButton.interactable = model.teleport.count > 0;
+    this.shuffleButton.interactable = model.canShuffle();
     this.bombButton.node.opacity = active === BoosterType.Bomb ? 180 : 255;
     this.teleportButton.node.opacity = active === BoosterType.Teleport ? 180 : 255;
+    const bombActive = this.bombButton.node.getComponent(ButtonActiveEffect)!;
+    const teleportActive = this.teleportButton.node.getComponent(ButtonActiveEffect)!;
+    bombActive.enabled = active === BoosterType.Bomb;
+    teleportActive.enabled = active === BoosterType.Teleport;
   }
 
   private onRestartDefault = () => {
@@ -121,6 +135,10 @@ export class UIManager {
 
   private onTeleportButton = () => {
     this.onBoosterSelect(BoosterType.Teleport);
+  };
+
+  private onShuffleButton = () => {
+    this.onShuffle();
   };
 }
 


### PR DESCRIPTION
## Summary
- implement manual shuffle and store shuffle limit in GameModel
- highlight active booster buttons with a pulsating effect
- add shuffle button handling in UIManager and GameController
- expose shuffle fields in GameController

## Testing
- `npx tsc --noEmit` *(fails: creator.d.ts:20916:66 - error TS1005: ',' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68597d5616788321b11fddb187c9b9e8